### PR TITLE
Remove redundant duplicate `DataPointCloudProduct.open_dataset`

### DIFF
--- a/ceda_datapoint/core/cloud.py
+++ b/ceda_datapoint/core/cloud.py
@@ -187,61 +187,6 @@ class DataPointCloudProduct(BasicAsset):
         """
         return self.open_dataset(local_only=local_only, prepare_data=prepare_data)
 
-    def open_dataset(
-            self, 
-            local_only: bool = False,
-            prepare_data: bool = True,
-            **kwargs
-        ) -> xr.Dataset:
-        """
-        Open the dataset for this product (in xarray).
-        Specific methods to open cloud formats are private since
-        the method should be determined by internal values not user
-        input.
-
-        :param local_only:  (bool) Switch to using local-only files - DataPoint will
-            convert all hrefs and internal Kerchunk links to use local paths.
-        """
-        if not self._cloud_format:
-            raise ValueError(
-                'No cloud format given for this dataset'
-            )
-        
-        if self.href is None:
-            raise ValueError(
-                'Cloud assets with no "href" are not supported'
-            )
-        
-        if self.visibility == 'local-only' and not local_only:
-            raise ValueError(
-                'Href not reachable via https, please use `local_only=True` '
-                'to open this dataset.'
-            )
-
-        try:
-            if self._cloud_format == 'kerchunk':
-                ds = self._open_kerchunk(local_only=local_only, **kwargs)
-            elif self._cloud_format == 'CFA':
-                ds = self._open_cfa(**kwargs)
-            elif self._cloud_format == 'zarr':
-                ds = self._open_zarr(**kwargs)
-            elif self._cloud_format == 'cog':
-                ds = self._open_cog(**kwargs)
-            else:
-                raise ValueError(
-                    'Cloud format not recognised - must be one of ("kerchunk", "CFA", "zarr", "cog")'
-                )
-            
-            return self._prepare_dataset(ds, prepare_data=prepare_data)
-
-        except ValueError as err:
-            raise err
-        except FileNotFoundError:
-            raise FileNotFoundError(
-                'The requested resource could not be located: '
-                f'{self.href}'
-            )
-
     def _open_kerchunk(
             self,
             local_only: bool = False,


### PR DESCRIPTION
`open_dataset` is defined twice on the `DataPointCloudProduct` class, here:

https://github.com/cedadev/datapoint/blob/ab06db0c0b761c3e415310d2b0e353cc9ad99652/ceda_datapoint/core/cloud.py#L190-L195

and here:

https://github.com/cedadev/datapoint/blob/ab06db0c0b761c3e415310d2b0e353cc9ad99652/ceda_datapoint/core/cloud.py#L524-L530

and therefore the first is unused because the second/last definition is taken. If this was C++ etc. I'd say it was overloading by signature but this is Python so I'm pretty sure that doesn't happen - think one method was left in by mistake?

So this quick PR tidies by removing the first unused definition.